### PR TITLE
Update build scripts for image dekn#8065

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,6 +49,7 @@ function run::build() {
 
       GOOS=linux \
       CGO_ENABLED=0 \
+      GOARCH=amd64 \
         go build \
           -ldflags="-s -w" \
           -o "run" \

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -140,7 +140,7 @@ function buildpackage::create() {
   pack \
     buildpack package "${output}" \
       --path "${BUILD_DIR}/buildpack.tgz" \
-      --format file
+      --format image
 }
 
 main "${@:-}"


### PR DESCRIPTION
To fix https://github.com/plotly/dekn/issues/8065


Main branch is already exempt of CVEs. We just need a release.

```
cnb/buildpacks/paketo-buildpacks_miniconda/5.4.0/bin/run (gobinary)
===================================================================
Total: 4 (UNKNOWN: 2, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)
```
